### PR TITLE
Add meta tags

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -22,6 +22,10 @@ config :logger, :console,
   format: "$time $metadata[$level] $message\n",
   metadata: [:request_id]
 
+config :blog, :image_uploader, Blog.ImageUploader
+config :blog, :title, "Another Flavor"
+config :blog, :description, "This blog's the hog"
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -26,8 +26,6 @@ config :blog, Blog.Endpoint,
     ]
   ]
 
-config :blog, :image_uploader, Blog.ImageUploader
-
 # Do not include metadata nor timestamps in development logs
 config :logger, :console, format: "[$level] $message\n"
 

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -18,8 +18,6 @@ config :blog, Blog.Endpoint,
   cache_static_manifest: "priv/static/manifest.json",
   secret_key_base: System.get_env("SECRET_KEY_BASE")
 
-config :blog, :image_uploader, Blog.ImageUploader
-
 # Do not print debug messages in production
 config :logger, level: :info
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -11,6 +11,9 @@ config :blog, :image_uploader, Blog.MockImageUploader
 # Print only warnings and errors during test
 config :logger, level: :warn
 
+config :blog, :title, "Blog Title"
+config :blog, :description, "Blog description"
+
 # Configure your database
 config :blog, Blog.Repo,
   adapter: Ecto.Adapters.Postgres,

--- a/lib/blog/post.ex
+++ b/lib/blog/post.ex
@@ -7,6 +7,7 @@ defmodule Blog.Post do
   schema "posts" do
     field :title, :string
     field :slug, :string
+    field :description, :string
     field :body, :string
     field :published_at, Ecto.DateTime
     field :publish, :boolean, virtual: true
@@ -23,10 +24,10 @@ defmodule Blog.Post do
   """
   def changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, [:title, :body, :publish])
+    |> cast(params, [:title, :body, :publish, :description])
     |> set_slug()
     |> set_published_at()
-    |> validate_required([:title, :slug, :body])
+    |> validate_required([:title, :slug, :body, :description])
     |> unique_constraint(:slug)
   end
 

--- a/priv/repo/migrations/20161229030717_add_description_to_posts.exs
+++ b/priv/repo/migrations/20161229030717_add_description_to_posts.exs
@@ -1,0 +1,9 @@
+defmodule Blog.Repo.Migrations.AddDescriptionToPosts do
+  use Ecto.Migration
+
+  def change do
+    alter table(:posts) do
+      add :description, :string
+    end
+  end
+end

--- a/priv/repo/migrations/20161230124618_add_index_on_public_to_pages.exs
+++ b/priv/repo/migrations/20161230124618_add_index_on_public_to_pages.exs
@@ -1,0 +1,7 @@
+defmodule Blog.Repo.Migrations.AddIndexOnPublicToPages do
+  use Ecto.Migration
+
+  def change do
+    create index(:pages, [:public])
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -1,14 +1,6 @@
 # Script for populating the database. You can run it as:
 #
 #     mix run priv/repo/seeds.exs
-#
-# Inside the script, you can read and write to any of your
-# repositories directly:
-#
-#     Blog.Repo.insert!(%Blog.SomeModel{})
-#
-# We recommend using the bang functions (`insert!`, `update!`
-# and so on) as they will fail if something goes wrong.
 
 alias Blog.Fabricator
 
@@ -17,6 +9,8 @@ tag_names = ["Personal", "Work", "Off Topic", "Rant", "Posts"]
 tags = for tag <- tag_names do
   Fabricator.create(:tag, %{name: tag})
 end
+
+Fabricator.create(:page, %{title: "About", description: "About the blog", body: "All about the blog"})
 
 for _ <- 1..2 do
   user = Fabricator.create(:user)

--- a/test/blog/post_test.exs
+++ b/test/blog/post_test.exs
@@ -3,7 +3,7 @@ defmodule Blog.PostTest do
 
   alias Blog.Post
 
-  @valid_attrs %{body: "Some content.", title: "The Title"}
+  @valid_attrs %{body: "Some content.", title: "The Title", description: "The description"}
   @invalid_attrs %{}
 
   test "changeset with valid attributes" do

--- a/test/blog/update_post_test.exs
+++ b/test/blog/update_post_test.exs
@@ -5,7 +5,7 @@ defmodule Blog.UpdatePostTest do
   import Blog.UpdatePost
 
   test "creates a post" do
-    {:ok, post} = update_post(%Post{user_id: Fabricator.create(:user).id}, %{"body" => "body", "title" => "title", "tags" => "Tag1, Tag2"})
+    {:ok, post} = update_post(%Post{user_id: Fabricator.create(:user).id}, %{"body" => "body", "title" => "title", "description" => "description", "tags" => "Tag1, Tag2"})
     assert post.id
     assert post.title == "title"
     assert post.body == "body"
@@ -14,29 +14,29 @@ defmodule Blog.UpdatePostTest do
 
   test "uses existing tags if they exist" do
     tag = Fabricator.create(:tag, %{name: "Tag1"})
-    {:ok, post} = update_post(%Post{user_id: Fabricator.create(:user).id}, %{"body" => "body", "title" => "title", "tags" => "Tag1"})
+    {:ok, post} = update_post(%Post{user_id: Fabricator.create(:user).id}, %{"body" => "body", "title" => "title", "description" => "description", "tags" => "Tag1"})
     post_tag = post.tags |> List.first
     assert post_tag.id == tag.id
   end
 
   test "both uses existing and creates new tags" do
     tag = Fabricator.create(:tag, %{name: "Tag1"})
-    {:ok, post} = update_post(%Post{user_id: Fabricator.create(:user).id}, %{"body" => "body", "title" => "title", "tags" => "Tag1, Tag2"})
+    {:ok, post} = update_post(%Post{user_id: Fabricator.create(:user).id}, %{"body" => "body", "title" => "title", "description" => "description", "tags" => "Tag1, Tag2"})
     first_tag = post.tags |> List.first
     assert first_tag.id == tag.id
     assert length(post.tags) == 2
   end
 
   test "removes tags from a post" do
-    {:ok, post} = update_post(%Post{user_id: Fabricator.create(:user).id}, %{"body" => "body", "title" => "title", "tags" => "Tag1, Tag2"})
-    {:ok, post} = update_post(post, %{"body" => "body", "title" => "title", "tags" => "Tag2"})
+    {:ok, post} = update_post(%Post{user_id: Fabricator.create(:user).id}, %{"body" => "body", "title" => "title", "description" => "description", "tags" => "Tag1, Tag2"})
+    {:ok, post} = update_post(post, %{"body" => "body", "title" => "title", "description" => "description", "tags" => "Tag2"})
     tags = post.tags
     assert length(tags) == 1
     assert List.first(tags).name == "Tag2"
   end
 
   test "previews a post" do
-    post = preview_post(%Post{user_id: Fabricator.create(:user).id}, %{"body" => "body", "title" => "title", "tags" => "Tag1, Tag2"})
+    post = preview_post(%Post{user_id: Fabricator.create(:user).id}, %{"body" => "body", "title" => "title", "description" => "description", "tags" => "Tag1, Tag2"})
     tags = post.tags
     assert length(tags) == 2
     assert post.body == "body"

--- a/test/controllers/page_controller_test.exs
+++ b/test/controllers/page_controller_test.exs
@@ -72,7 +72,7 @@ defmodule Blog.PageControllerTest do
     conn = conn
     |> with_current_user(user)
     |> put(page_path(conn, :update, page), page: @valid_attrs)
-    assert redirected_to(conn) == page_path(conn, :show, page)
+    assert redirected_to(conn) == page_path(conn, :index)
     assert Repo.get_by(Page, @valid_attrs)
   end
 

--- a/test/controllers/post_controller_test.exs
+++ b/test/controllers/post_controller_test.exs
@@ -2,7 +2,7 @@ defmodule Blog.PostControllerTest do
   use Blog.ConnCase
 
   alias Blog.{Post, Fabricator}
-  @valid_attrs %{body: "some content", title: "some content"}
+  @valid_attrs %{body: "some content", title: "some content", description: "some content"}
   @invalid_attrs %{body: "", title: ""}
 
   test "lists all published entries on index", %{conn: conn} do

--- a/test/support/fabricator.ex
+++ b/test/support/fabricator.ex
@@ -7,7 +7,7 @@ defmodule Blog.Fabricator do
     Blog.User.changeset(%Blog.User{}, set_params)
   end
   def changeset(:post, params) do
-    set_params = Map.merge(%{title: Faker.Lorem.sentence(10), body: Faker.Lorem.paragraph(%Range{first: 2, last: 4}), user: build(:user), publish: true}, params)
+    set_params = Map.merge(%{title: Faker.Lorem.sentence(10), body: Faker.Lorem.paragraph(%Range{first: 2, last: 4}), user: build(:user), publish: true, description: "The description"}, params)
     Blog.Post.changeset(%Blog.Post{user: set_params.user}, set_params)
   end
   def changeset(:tag, params) do

--- a/test/views/layout_view_test.exs
+++ b/test/views/layout_view_test.exs
@@ -30,4 +30,32 @@ defmodule Blog.LayoutViewTest do
     link = page_link(%Plug.Conn{request_path: "/other"}, %Blog.Page{slug: "about"}) |> safe_to_string()
     refute String.match?(link, ~r/is-active/)
   end
+
+  test "title_for with a post" do
+    conn = %Plug.Conn{assigns: %{post: %Blog.Post{title: "Post Title"}}}
+    assert title_for(conn) == "Post Title | Blog Title"
+  end
+
+  test "title_for with a page" do
+    conn = %Plug.Conn{assigns: %{page: %Blog.Page{title: "Page Title"}}}
+    assert title_for(conn) == "Page Title | Blog Title"
+  end
+
+  test "title_for with neither" do
+    assert title_for(%Plug.Conn{}) == "Blog Title"
+  end
+
+  test "description_for with a post" do
+    conn = %Plug.Conn{assigns: %{post: %Blog.Post{description: "Post description"}}}
+    assert description_for(conn) == "Post description"
+  end
+
+  test "description_for with a page" do
+    conn = %Plug.Conn{assigns: %{page: %Blog.Page{description: "Page description"}}}
+    assert description_for(conn) == "Page description"
+  end
+
+  test "description_for with neither" do
+    assert description_for(%Plug.Conn{}) == "Blog description"
+  end
 end

--- a/web/controllers/page_controller.ex
+++ b/web/controllers/page_controller.ex
@@ -48,7 +48,7 @@ defmodule Blog.PageController do
       {:ok, page} ->
         conn
         |> put_flash(:info, "Page updated successfully.")
-        |> redirect(to: page_path(conn, :show, page))
+        |> redirect(to: page_path(conn, :index))
       {:error, changeset} ->
         render(conn, "edit.html", page: page, changeset: changeset)
     end

--- a/web/static/js/post-form.jsx
+++ b/web/static/js/post-form.jsx
@@ -25,6 +25,7 @@ export default class extends React.Component {
     this.state = {
       activeTab: tabNames[0],
       title: this.props.changeset.post.title || '',
+      description: this.props.changeset.post.description || '',
       body: this.props.changeset.post.body || '',
       tags: this.props.changeset.post.tags || '',
       publish: this.props.changeset.post.publish || false,
@@ -91,6 +92,7 @@ export default class extends React.Component {
         action={this.props.changeset.action}
         post={this.props.changeset.post}
         title={this.state.title}
+        description={this.state.description}
         body={this.state.body}
         tags={this.state.tags}
         publish={this.state.publish}

--- a/web/static/js/post-form/post-form.jsx
+++ b/web/static/js/post-form/post-form.jsx
@@ -9,6 +9,7 @@ export default class extends React.Component {
       action: React.PropTypes.string,
       errors: React.PropTypes.object.isRequired,
       title: React.PropTypes.string,
+      description: React.PropTypes.string,
       body: React.PropTypes.string,
       tags: React.PropTypes.string,
       publish: React.PropTypes.bool,
@@ -65,6 +66,15 @@ export default class extends React.Component {
                 readOnly: true,
                 defaultValue: this.props.post.slug,
                 placeholder: 'Will be generated automatically',
+              }}
+            />
+            <Input
+              name="post[description]"
+              label="Description"
+              error={this.errorFor('description')}
+              inputProps={{
+                defaultValue: this.props.description,
+                onChange: e => this.props.changeField('description', e.target.value),
               }}
             />
             <TextArea

--- a/web/templates/layout/app.html.eex
+++ b/web/templates/layout/app.html.eex
@@ -16,7 +16,7 @@
         <div class="container">
           <nav class="nav">
             <div class="nav-left">
-              <%= link to: post_path(@conn, :index), class: "nav-item is-brand" do %>
+              <%= link to: post_path(@conn, :index), class: "nav-item" do %>
                 <h1 class="title" itemprop="name"><%= title %></h1>
               <% end %>
               <meta itemprop="description" content="<%= description %>">

--- a/web/templates/layout/app.html.eex
+++ b/web/templates/layout/app.html.eex
@@ -4,19 +4,22 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Blog</title>
+    <title><%= title_for(@conn) %></title>
+    <meta name="description" content="<%= description_for(@conn) %>">
+    <%= og_meta_tags(@conn) %>
     <link rel="stylesheet" href="<%= static_path(@conn, "/css/app.css") %>">
   </head>
 
-  <body>
+  <body itemscope itemtype="http://schema.org/Blog">
     <section class="hero is-primary">
       <div class="hero-head">
         <div class="container">
           <nav class="nav">
             <div class="nav-left">
               <%= link to: post_path(@conn, :index), class: "nav-item is-brand" do %>
-                <h1 class="title">Blog</h1>
+                <h1 class="title" itemprop="name"><%= title %></h1>
               <% end %>
+              <meta itemprop="description" content="<%= description %>">
             </div>
 
             <span id="nav-toggle" class="nav-toggle">

--- a/web/views/layout_view.ex
+++ b/web/views/layout_view.ex
@@ -1,6 +1,9 @@
 defmodule Blog.LayoutView do
   use Blog.Web, :view
 
+  @title Application.get_env(:blog, :title)
+  @description Application.get_env(:blog, :description)
+
   def pages do
     Blog.Page
     |> Blog.Page.public()
@@ -25,5 +28,43 @@ defmodule Blog.LayoutView do
     else
       "nav-item"
     end
+  end
+
+  def title, do: @title
+  def description, do: @description
+
+  def title_for(%{assigns: %{post: post}}) do
+    "#{post.title} | #{title}"
+  end
+  def title_for(%{assigns: %{page: page}}) do
+    "#{page.title} | #{title}"
+  end
+  def title_for(_conn), do: title
+
+  def description_for(%{assigns: %{post: post}}), do: post.description
+  def description_for(%{assigns: %{page: page}}), do: page.description
+  def description_for(_conn), do: description
+
+  def og_meta_tags(conn=%{assigns: %{post: post}}) do
+    [
+      tag(:meta, property: "og:url", content: post_url(conn, :show, post)),
+      tag(:meta, property: "og:type", content: "article"),
+      tag(:meta, property: "og:title", content: post.title),
+      tag(:meta, property: "og:description", content: post.description)
+    ]
+  end
+  def og_meta_tags(conn=%{assigns: %{page: page}}) do
+    [
+      tag(:meta, property: "og:url", content: page_url(conn, :show, page)),
+      tag(:meta, property: "og:title", content: page.title),
+      tag(:meta, property: "og:description", content: page.description)
+    ]
+  end
+  def og_meta_tags(conn) do
+    [
+      tag(:meta, property: "og:url", content: post_url(conn, :index)),
+      tag(:meta, property: "og:title", content: title),
+      tag(:meta, property: "og:description", content: description)
+    ]
   end
 end

--- a/web/views/post_view.ex
+++ b/web/views/post_view.ex
@@ -34,6 +34,7 @@ defmodule Blog.PostView do
       id: post.id,
       body: post.body,
       title: post.title,
+      description: post.description,
       slug: post.slug,
       publish: published(changeset),
       tags: tag_value(changeset)


### PR DESCRIPTION
This pull makes a meta description is always shown and updates the title for pages with a post or page to something more descriptive. It also adds some basic schema.org top level blog stuff and open graph tags (excluding an image).

This also makes the title of the blog configurable.